### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "scripts": {
     "start": "eleventy --serve & postcss styles/tailwind.css --o _tmp/style.css --watch",
-    "build": "ELEVENTY_PRODUCTION=true eleventy & NODE_ENV=production postcss styles/tailwind.css --o _site/style.css"
+    "build": "ELEVENTY_PRODUCTION=true eleventy && NODE_ENV=production postcss styles/tailwind.css --o _site/style.css"
   },
   "devDependencies": {
     "@11ty/eleventy": "^0.11.0",


### PR DESCRIPTION
I ran into problems using `&` to run postcss after running eleventy when using fetch to pull data asynchronously from an API in the _data folder. It looks like npm was running the second command before waiting for eleventy to fetch and build. Switching `&` to `&&` allows the first command to finish and fixes the issue.