### PR TITLE
Add defer to alpine's script tag

### DIFF
--- a/_includes/default.njk
+++ b/_includes/default.njk
@@ -12,7 +12,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no, viewport-fit=cover"/>
     <link rel="stylesheet" href="/style.css?v={% version %}"/>
     {% block head %}{% endblock %}
-    <script src="/js/alpine.js?v={% version %}"></script>
+    <script defer src="/js/alpine.js?v={% version %}"></script>
   </head>
   <body>
     {% block content %}


### PR DESCRIPTION
This PR simply adds the missing `defer` property from the script tag to get rid of the following warning from AlpineJS:

![image](https://user-images.githubusercontent.com/45761672/124826081-575b5f00-df6c-11eb-98cb-e42cbe99b594.png)

I found this in a CSS Tricks article, and found it super useful. Didn't know how to give back, so here's a tiny bit of housekeeping in thanks! Also, my first PR on Github, so apologies if it's not standard!